### PR TITLE
Make the bot not stride to far away from start pos.

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,8 @@
         "KEEP_CP_OVER": 500,
         "RELEASE_DUPLICATE": false,
         "DUPLICATE_CP_FOREGIVENESS": 0.90,
-        "STEP_SIZE": 100
+        "STEP_SIZE": 100,
+        "RETURN_START_INTERVAL": 20
     },
     {  "auth_service": "ptc",
         "username": "USERNAME_HERE",
@@ -22,6 +23,7 @@
         "KEEP_CP_OVER": 200,
         "RELEASE_DUPLICATE": false,
         "DUPLICATE_CP_FOREGIVENESS": 0.90,
-        "STEP_SIZE": 100
+        "STEP_SIZE": 100,
+        "RETURN_START_INTERVAL": 20
     }
     ]}

--- a/pokebot.py
+++ b/pokebot.py
@@ -79,9 +79,8 @@ def main():
         return
 
     pokemon_names = json.load(open("name_id.json"))
-    api = PGoApi(config.__dict__, pokemon_names)
 
-    api.set_position(*position)
+    api = PGoApi(config.__dict__, pokemon_names, position)
 
     if not api.login(config.auth_service, config.username, config.password, config.cached):
         return


### PR DESCRIPTION
After a little while the bot will now select a fort close to starting
position as the next fort. This makes sure the bot stays in close
proximity to the starting location. To make sure the bot does not
allways use the same stops it will now select them randomly.
Meaning that when traveling away from the starting
position the next time, it might take a totally different
path visiting different stops.

Why would you want this changed?
Most of the people using the bot selects either a high density spot like central park or somewhere else where we expect to find loads of pokemons, or a spot nearby. If you run the bot for a couple of hours it might walk pretty far away from the original spot. Meaning it might be in a low density area catching very few pokemons or somewhere far away from home leading to you getting soft-banned if you login with the app rather than the script.

Both of those problems are solved by making the bot select a fort near startingposition every now and then.