### PR TITLE
Add ability to release duplicate pokemon if desired

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,8 @@
         "GMAPS_API_KEY": "INSERT_API_KEY_HERE",
         "MIN_KEEP_IV" : 50,
         "KEEP_CP_OVER": 500,
+        "RELEASE_DUPLICATE": false,
+        "DUPLICATE_CP_FOREGIVENESS": 0.90,
         "STEP_SIZE": 100
     },
     {  "auth_service": "ptc",
@@ -18,6 +20,8 @@
         "GMAPS_API_KEY": "INSERT_API_KEY_HERE",
         "MIN_KEEP_IV" : 50,
         "KEEP_CP_OVER": 200,
+        "RELEASE_DUPLICATE": false,
+        "DUPLICATE_CP_FOREGIVENESS": 0.90,
         "STEP_SIZE": 100
     }
     ]}

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -56,7 +56,7 @@ class PGoApi:
         self._posf = (0,0,0)
         self.MIN_KEEP_IV = config.get("MIN_KEEP_IV", 0)
         self.KEEP_CP_OVER = config.get("KEEP_CP_OVER", 0)
-        self.RELEASE_DUPLICATES = config.get("RELEASE_DUPLICATES", 0)
+        self.RELEASE_DUPLICATES = config.get("RELEASE_DUPLICATE", 0)
         self.DUPLICATE_CP_FORGIVENESS = config.get("DUPLICATE_CP_FOREGIVENESS", 0)
         self._req_method_list = []
         self._heartbeat_number = 5


### PR DESCRIPTION
Config now contains an option to release duplicate pokemon, keeping the one with the highest CP. Also added the ability to only release pokemon that are below xx% CP of the top CP pokemon